### PR TITLE
Use interfaces, where possible.

### DIFF
--- a/ArgumentParser/ParsedArguments.cs
+++ b/ArgumentParser/ParsedArguments.cs
@@ -7,29 +7,53 @@ namespace ArgumentParser
 {
     public class ParsedArguments
     {
-        public ReadOnlyCollection<string> Arguments { get; }
-        public ReadOnlyCollection<int> IntegerArguments { get; }
-        public ReadOnlyCollection<decimal> DecimalArguments { get; }
-        public ReadOnlyCollection<string> StringArguments { get; }
-        public ReadOnlyDictionary<string, string> NamedArguments { get; }
+        /// <summary>
+        /// All parsed arguments
+        /// </summary>
+        public IReadOnlyList<string> Arguments { get; }
 
-        // By only trying to parse the StringArguments to the enum,
-        // this will ignore integer parameters which could map to an enum value.
+        /// <summary>
+        /// Parsed integer arguments
+        /// </summary>
+        public IReadOnlyList<int> IntegerArguments { get; }
+
+        /// <summary>
+        /// Parsed decimal arguments
+        /// </summary>
+        public IReadOnlyList<decimal> DecimalArguments { get; }
+
+        /// <summary>
+        /// Parsed string arguments, not including named (key/value) arguments
+        /// </summary>
+        public IReadOnlyList<string> StringArguments { get; }
+
+        /// <summary>
+        /// Parsed named arguments, where the key is the argument name and the value is the argument value
+        /// </summary>
+        public IReadOnlyDictionary<string, string> NamedArguments { get; }
+
+        /// <summary>
+        /// Returns all enum arguments of the specified type, parsed from the string arguments.
+        /// This only checks string arguments, not named arguments or integer/decimal arguments,
+        /// to prevent confusion with numeric values that might match enum option integer values.
+        /// </summary>
+        /// <typeparam name="T">Enum to check options against string arguments</typeparam>
+        /// <returns>IEnumerable of string parameters that match a value of the enum</returns>
         public IEnumerable<T> EnumArgumentsOfType<T>() where T : struct =>
             StringArguments.Where(a => Enum.TryParse(a, true, out T _))
                 .Select(a => (T)Enum.Parse(typeof(T), a, true));
 
         public ParsedArguments(
-            List<string> arguments, 
-            List<int> integerArguments, 
-            List<decimal> decimalArguments, 
-            List<string> stringArguments, 
-            Dictionary<string, string> namedArguments)
+            IEnumerable<string> arguments,
+            IEnumerable<int> integerArguments,
+            IEnumerable<decimal> decimalArguments,
+            IEnumerable<string> stringArguments,
+            IDictionary<string, string> namedArguments)
         {
-            Arguments = arguments.AsReadOnly();
-            IntegerArguments = integerArguments.AsReadOnly();
-            DecimalArguments = decimalArguments.AsReadOnly();
-            StringArguments = stringArguments.AsReadOnly();
+            Arguments = new ReadOnlyCollection<string>(arguments.ToList());
+            IntegerArguments = new ReadOnlyCollection<int>(integerArguments.ToList());
+            DecimalArguments = new ReadOnlyCollection<decimal>(decimalArguments.ToList());
+            StringArguments = new ReadOnlyCollection<string>(stringArguments.ToList());
             NamedArguments = new ReadOnlyDictionary<string, string>(namedArguments);
         }
     }

--- a/ArgumentParser/Parser.cs
+++ b/ArgumentParser/Parser.cs
@@ -36,13 +36,17 @@ namespace ArgumentParser
 
         #region Public Methods
 
+        /// <summary>
+        /// Parses a string of arguments into a ParsedArguments object.
+        /// </summary>
+        /// <param name="args">Array of string arguments to parse</param>
+        /// <returns>ParsedArguments object, populate with values from arguments parameter</returns>
         public ParsedArguments Parse(string[] args)
         {
             var integerArguments = new List<int>();
             var decimalArguments = new List<decimal>();
             var stringArguments = new List<string>();
             var namedArguments = new Dictionary<string, string>();
-            var flags = new List<string>();
 
             foreach (var arg in args)
             {
@@ -72,18 +76,16 @@ namespace ArgumentParser
                 namedArguments);
         }
 
+        /// <summary>
+        /// Parses a string of arguments into a ParsedArguments object.
+        /// </summary>
+        /// <param name="arguments">String containing arguments to parse</param>
+        /// <returns>ParsedArguments object, populate with values from arguments parameter</returns>
         public ParsedArguments Parse(string arguments)
         {
-            string[] splitArgs;
-
-            if (_stringArgSeparators != null)
-            {
-                splitArgs = SplitByStringSeparators(arguments, _stringArgSeparators);
-            }
-            else
-            {
-                splitArgs = arguments.Split(_argSeparators, StringSplitOptions.RemoveEmptyEntries);
-            }
+            string[] splitArgs = _stringArgSeparators != null
+                ? arguments.Split(_stringArgSeparators, StringSplitOptions.RemoveEmptyEntries)
+                : arguments.Split(_argSeparators, StringSplitOptions.RemoveEmptyEntries);
 
             return Parse(splitArgs);
         }
@@ -92,26 +94,25 @@ namespace ArgumentParser
 
         #region Private Methods
 
-        private bool TryParseNamedArgument(string argument, out KeyValuePair<string, string> namedArgument)
+        private bool TryParseNamedArgument(string argument, 
+            out KeyValuePair<string, string> namedArgument)
         {
             int separatorIndex = argument.IndexOfAny(_keyValueSeparators);
 
-            if (separatorIndex >= 0)
+            // No separator found, or was found in the first position,
+            // so this is not a named argument.
+            if (separatorIndex < 1)
             {
-                string key = argument.Substring(0, separatorIndex);
-                string value = argument.Substring(separatorIndex + 1);
-
-                namedArgument = new KeyValuePair<string, string>(key, value);
-
-                return true;
+                return false;
             }
 
-            return false;
-        }
+            // Split the argument into key and value parts.
+            namedArgument =
+                new KeyValuePair<string, string>(
+                    argument.Substring(0, separatorIndex),
+                    argument.Substring(separatorIndex + 1));
 
-        private string[] SplitByStringSeparators(string input, string[] separators)
-        {
-            return input.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+            return true;
         }
 
         #endregion

--- a/Test.ArgumentParser/TestParser.cs
+++ b/Test.ArgumentParser/TestParser.cs
@@ -64,4 +64,20 @@ public class TestParser
 
         Assert.Equal(2, parsedArguments.Arguments.Count);
     }
+
+    [Fact]
+    public void Test_KeyValueSeparatorInFirstPosition()
+    {
+        var parser = new Parser(new[] { ' ' }, new[] { '=' });
+
+        var parsedArguments = parser.Parse("=1");
+
+        Assert.Single(parsedArguments.Arguments);
+        Assert.Empty(parsedArguments.IntegerArguments);
+        Assert.Empty(parsedArguments.DecimalArguments);
+        Assert.Single(parsedArguments.StringArguments);
+        Assert.Empty(parsedArguments.EnumArgumentsOfType<EmployeeType>());
+        Assert.Empty(parsedArguments.NamedArguments);
+        Assert.Equal("=1", parsedArguments.Arguments[0]);
+    }
 }


### PR DESCRIPTION
If first character of argument is key/value separator, don't treat as named argument.

Closes #23 

Closes #24 